### PR TITLE
added unique identifier for mapbox polygon source 

### DIFF
--- a/maps-mapbox/src/iosMain/kotlin/dev/icerock/moko/maps/mapbox/MapboxController.kt
+++ b/maps-mapbox/src/iosMain/kotlin/dev/icerock/moko/maps/mapbox/MapboxController.kt
@@ -180,7 +180,6 @@ actual class MapboxController(
         lineOpacity: Float,
         lineType: LineType
     ): MapElement {
-
         val polygon: MGLPolygonFeature = memScoped {
 
             val items = createValues<CLLocationCoordinate2D>(pointList.count()) { pos ->
@@ -199,10 +198,10 @@ actual class MapboxController(
         )
         delegate.polygonSettings[polygon.hashCode()] = settings
 
-        val source = MGLShapeSource(identifier = "line", shape = polygon, options = null)
+        val source = MGLShapeSource(identifier = "line:${(0..Int.MAX_VALUE).random()}", shape = polygon, options = null)
         delegate.style?.addSource(source)
 
-        val layer = MGLLineStyleLayer(identifier = "line-layer", source = source)
+        val layer = MGLLineStyleLayer(identifier = "line-layer:${(0..Int.MAX_VALUE).random()}", source = source)
         if (lineType == LineType.DASHED) {
             layer.lineDashPattern =
                 NSExpression.expressionForConstantValue(List<Double>(2) { 2.0 })


### PR DESCRIPTION
to fix crash 
```
Fatal Exception: MGLRedundantSourceIdentifierException
Source line already exists
```
crash was when you draw two polygons on one map